### PR TITLE
Add preconditions for letting others contribute

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -12,6 +12,10 @@
         "@upstash/context7-mcp@latest"
       ],
       "env": {}
+    },
+    "puppeteer": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-puppeteer"]
     }
   }
 }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -11,6 +11,10 @@
                 "-y",
                 "@upstash/context7-mcp@latest"
             ]
+        },
+        "puppeteer": {
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-puppeteer"]
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Huddlz follows a streamlined development process optimized for solo development 
 
 See [Development Lifecycle](docs/development_lifecycle.md) for detailed information.
 
+## Developer Setup - (current default) "To make micah style pr's!"
+1. 100$ month claude plan
+2. make sure mcp.json is up to date
+3. vscode (optional) - you can run claude commands from terminal
+4. ghostty terminal (optional)
+
 ### Testing
 
 * Run all tests: `mix test`


### PR DESCRIPTION
## Huddlz talk yesterday
Introduced baby sitting ai and letting it do most of the work with small adjustments to prompting.
This pr aims to put the process into the hands of other developers who may or may not be familiar with the ash framework. The goal of this process is to get pr's up in a more groomed state than you would get with ai alone. The Repo Author/Maintainer still reviews the final pr but the odds of failure needing for more prompting by the Repo Author are greatly reduced.

Possible outcomes.
1. The ai one-shots the feature.
2. The ai + the developer watching it one-shots the feature.
3. (rare) Something goes wrong. That the external developer cannot resolve alongside the ai.
maybe they try again and submit another pr.
or maybe they give up and document they wont do the feature and pick a different feature and put down that task.
4. ^ All of the above outcomes go to Library Author/Maintainer for final review.

## What is in it for the external developer?
1. They are able to collaborate on the Library Author's project. With the developer working on features that the author cares about within the guidelines setup for the library. Allowing the author to build additional features or just focus on feature priority.
2. They receive a gentle introduction to using ai every day. 
When you already are using a tool it is easy to use it for your other projects.

## Questions for Micah:
Which of these packages do you have installed locally?
```bash
npm ls -g @upstash/context7-mcp@latest @agent-infra/mcp-server-browser@latest @modelcontextprotocol/server-puppeteer" ; 
npm ls @upstash/context7-mcp@latest @agent-infra/mcp-server-browser@latest @modelcontextprotocol/server-puppeteer" ; 
```

Are these the correct preconditions to be able to "baby sit" the ai and get the pr's to 95 percent where you want them to be?