### PR TITLE
Add redirect with url

### DIFF
--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -53,10 +53,8 @@ defmodule HuddlzWeb.Layouts do
       <div class="navbar-end flex items-center gap-4">
         <%= if @current_user do %>
           <div class="dropdown dropdown-end">
-            <label tabindex="0" class="btn btn-ghost btn-circle avatar">
-              <div class="w-10 rounded-full bg-base-300 flex items-center justify-center">
-                <.icon name="hero-user" class="h-6 w-6" />
-              </div>
+            <label tabindex="0" class="btn btn-ghost btn-circle avatar rounded-full bg-base-300">
+              <.icon name="hero-user" class="h-6 w-6" />
             </label>
             <ul
               tabindex="0"

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -77,6 +77,9 @@ defmodule HuddlzWeb.HuddlLive.Show do
               <.icon name="hero-trash" class="h-4 w-4" /> Delete Huddl
             </button>
           <% end %>
+          <%= if !@current_user && @huddl.status == :upcoming do %>
+            <a href={"/register/?redirect_url=#{@huddl.group.slug}/huddlz/#{@huddl.id}"} class="btn btn-primary btn-soft">Auth and RSVP</a>
+          <% end %>
           <%= if @current_user && @huddl.status == :upcoming do %>
             <%= if @has_rsvped do %>
               <div class="flex items-center gap-4">

--- a/tasks/issue-34/learnings.md
+++ b/tasks/issue-34/learnings.md
@@ -57,10 +57,8 @@ end
 **Implementation**:
 ```heex
 <div class="dropdown dropdown-end">
-  <label tabindex="0" class="btn btn-ghost btn-circle avatar">
-    <div class="w-10 rounded-full bg-base-300 flex items-center justify-center">
-      <.icon name="hero-user" class="h-6 w-6" />
-    </div>
+  <label tabindex="0" class="btn btn-ghost btn-circle avatar rounded-full bg-base-300">
+    <.icon name="hero-user" class="h-6 w-6" />
   </label>
   <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
     <!-- menu items -->


### PR DESCRIPTION
What needs to be done: (Plan)
1. user clicks Auth and RSVP
2. redirect-url is saved with value rsvp-clicked.
3. upon successful authentication user is sent back to the huddl and rsvp'd

Current implementation:
1. Button exists with "Auth and RSVP" text for non logged in user. ✅
2. Redirect to register with redirect-to="url" included. ✅
3. When you click "sign-in" forward the redirect_url there too.
4. Upon successful login do not navigate to home page. Navigate back to the redirect_url instead.
5. On the redirected to page; In either the mount, handle_params, or other hook: 
do the action of rsvp'ing and remove the state from the url that would trigger that behavior.

Note. Sign In and Register potentially do not need to forward and manage the redirect_url state with a potential redirect-back or authorized `ash_authentication_live_session :authenticated_only`

Future rework:
1. Button exists with "Auth and RSVP" text for non logged in user.
2. Trigger Ash Framework redirect-back behavior 
> It should force login and/or register and upon login execute the callback to "rsvp the user".
Note: (I did some initial research on this and ran into trouble finding the docs for the effort.) 